### PR TITLE
Typo Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Etherspot Wallet Demo
 
-This is a wallet UI application that showcases the usage of Etherspot UI components. Developers can use this as a guide when building their own applications using Etherspot UI. Etherspot UI components created using Etherspot Transaction Kit for sending transactions, sending ERC tokens, and other Ethereum-related functionalities which are running on blockchain. For styling of all components of Etherspot UI, tailwind has been configured so, developer can use tailwind default classes and override tailwind css using simple styling also.
+This is a wallet UI application that showcases the usage of Etherspot UI components. Developers can use this as a guide when building their own applications using Etherspot UI. Etherspot UI components created using Etherspot Transaction Kit for sending transactions, sending ERC tokens, and other Ethereum-related functionalities which are running on blockchain. For styling of all components of Etherspot UI, tailwind has been configured so, developers can use tailwind default classes and override tailwind css using simple styling also.
 
 ## Getting Started
 


### PR DESCRIPTION
<img width="862" alt="Снимок экрана 2024-11-09 в 20 56 02" src="https://github.com/user-attachments/assets/8a7c4d4c-4524-425a-8e36-8e75b6fa798b">

"developer can use tailwind default classes": It should be "**developers**" (plural) for consistency in the sentence.

Corrected.